### PR TITLE
Added support for .net 4.7.2 framework

### DIFF
--- a/Source/AssemblyResolver.cs
+++ b/Source/AssemblyResolver.cs
@@ -108,7 +108,7 @@ namespace CSScriptLibrary
         {
             try
             {
-                if (asmFile.EndsWith(".cs"))
+                if (asmFile.EndsWith(".cs") || asmFile.EndsWith(".xml"))
                     return null;
 
                 AssemblyName asmName = AssemblyName.GetAssemblyName(asmFile);

--- a/Source/CSScriptLibrary/CSScriptLibrary.csproj
+++ b/Source/CSScriptLibrary/CSScriptLibrary.csproj
@@ -239,7 +239,6 @@
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>
-    <PostBuildEvent>
-    </PostBuildEvent>
+    <PostBuildEvent>$(ProjectDir)projexport.bat $(TargetPath)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Source/CSScriptLibrary/projexport.bat
+++ b/Source/CSScriptLibrary/projexport.bat
@@ -1,0 +1,32 @@
+@echo off
+rem ------------------------------------------------------------------------------------
+rem Setting up from Visual Studio: Add post build step:
+rem
+rem     $(ProjectDir)projexport.bat $(TargetPath)
+rem ------------------------------------------------------------------------------------
+setlocal enabledelayedexpansion
+if not "%~1" == "" goto next1
+    echo Usage: %0 ^<binary to copy^>
+    exit /b 1
+
+:next1
+
+set ProbeDir.AnyCPU.1="C:\anyfolder"
+
+for /f "tokens=2 delims==" %%a in ('set ProbeDir.AnyCPU. 2^>nul') do (
+    if exist "%%~a" (
+        echo Copying %~nx1/pdb/xml to %%~a...
+        if exist %~dpn1.pdb (
+            copy /Y %~dpn1.pdb "%%~a" >NUL
+        )
+        rem API interface xml description file
+        if exist %~dpn1.xml (
+            copy /Y %~dpn1.xml "%%~a" >NUL
+        )
+        copy /Y %1 "%%~a" >NUL
+    )
+)
+
+endlocal
+exit /b 
+

--- a/Source/csscript.bat
+++ b/Source/csscript.bat
@@ -1,0 +1,11 @@
+@echo off
+rem Pinpoint to location where you keep installation of C# script.
+rem set "CS-S_DEV_ROOT=%~dp0"
+
+set "CS-S_DEV_ROOT=C:\Installs\tools\cs-script"
+
+if not exist "%CS-S_DEV_ROOT%" (
+    echo Directory '%CS-S_DEV_ROOT%' does not exist
+    exit /b 1
+)
+"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\devenv.exe" csscript.sln

--- a/Source/csscript.cs
+++ b/Source/csscript.cs
@@ -1317,7 +1317,11 @@ namespace csscript
         {
 #pragma warning disable 618
             var providerOptions = new Dictionary<string, string>();
-            providerOptions["CompilerVersion"] = options.TargetFramework;
+            //
+            // Should be always "v4.0" even for later .net frameworks.
+            // https://stackoverflow.com/questions/13253967/how-to-target-net-4-5-with-csharpcodeprovider
+            //
+            providerOptions["CompilerVersion"] = "v4.0";
             return new CSharpCodeProvider(providerOptions).CreateCompiler();
 #pragma warning restore 618
         }

--- a/Source/deployment/lib/debugVS15.0.cs
+++ b/Source/deployment/lib/debugVS15.0.cs
@@ -1346,7 +1346,7 @@ namespace VS150 //Visual Studio 2017
                 try
                 {
                     //<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-                    ReplaceInFile(file, "<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>", "<TargetFrameworkVersion>" + target + "</TargetFrameworkVersion>");
+                    ReplaceInFile(file, "<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>", "<TargetFrameworkVersion>" + target + "</TargetFrameworkVersion>");
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Patches are targeted only for .net 4.7.2 haven't tested backwards compatibility.

Default css_config.xml needs additional flag:

`  <enableDbgPrint>True</enableDbgPrint>
  <TargetFramework>v4.7.2</TargetFramework>
</CSSConfig>`

TargetFramework otherwise will not work.
