### PR TITLE
Update CodeDOMEval.cs

### DIFF
--- a/Source/Tests/CodeDOMEval.cs
+++ b/Source/Tests/CodeDOMEval.cs
@@ -65,7 +65,7 @@ public class CodeDomEval
         var ex = Assert.Throws<CompilerException>(() =>
             CSScript.CodeDomEvaluator.CompileCode(classCode.Replace("public", "error_word")));
 
-        Assert.Contains("error CS0116: A namespace cannot directly contain", ex.Message);
+        Assert.Contains(" CS0116:", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
The test failed before on a German Windows as the error message read:

c:\temp\CSSCRIPT\dynamic\8164.ef676619-44ac-4e2f-a80a-f4f850083a99.tmp(1,1): error CS0116: Ein Namespace kann nicht direkt Member, wie z.B. Felder oder Methoden, enthalten.