### PR TITLE
Update CodeDom.cs

### DIFF
--- a/Source/Tests/CodeDom.cs
+++ b/Source/Tests/CodeDom.cs
@@ -44,7 +44,7 @@ public class CodeDom : TestBase
         {
             var ex = Assert.Throws<CompilerException>(() =>
                          CSScript.CompileCode(classCode.Replace("public", "error_word")));
-            Assert.Contains("error CS0116: A namespace cannot directly contain", ex.Message);
+            Assert.Contains(" CS0116:", ex.Message);
         }
     }
 


### PR DESCRIPTION
On a German Windows the test failed because the message read:

c:\temp\CSSCRIPT\11612.1a78afde-4d14-4b67-a691-b716bf9a86cc.tmp(1,1): error CS0116: Ein Namespace kann nicht direkt Member, wie z.B. Felder oder Methoden, enthalten.