### PR TITLE
Update AsmHelper.cs

### DIFF
--- a/Source/CSScriptLibrary/AsmHelper.cs
+++ b/Source/CSScriptLibrary/AsmHelper.cs
@@ -1305,7 +1305,7 @@ namespace CSScriptLibrary
 
         public T AlignToInterface<T>(object obj) where T : class
         {
-            Debug.Assert(false);
+            //Debug.Assert(false);
 
             var retval = CSScriptLibrary.ThirdpartyLibraries.Rubenhak.Utils.ObjectCaster<T>.As(obj);
 


### PR DESCRIPTION
There was an undocumented "Debug.Assert(false);" interfering with the provided samples (method "CodeDomSamples.ExecuteAndUnload").

If this method is for whatever reasons deprecated, please flag it as such instead, e.g.
[Obsolete("Use xxx instead.")]