### PR TITLE
Fixed issue where Example.Sub assembly would be matched when requesting Example assembly

### DIFF
--- a/Source/AssemblyResolver.cs
+++ b/Source/AssemblyResolver.cs
@@ -114,7 +114,7 @@ namespace CSScriptLibrary
                 AssemblyName asmName = AssemblyName.GetAssemblyName(asmFile);
                 if (asmName != null && asmName.FullName == assemblyName)
                     return Assembly.LoadFrom(asmFile);
-                else if (assemblyName.IndexOf(",") == -1 && asmName.FullName.StartsWith(assemblyName)) //short name requested
+                else if (assemblyName.IndexOf(",") == -1 && asmName.FullName.StartsWith(assemblyName + ",")) //short name requested
                     return Assembly.LoadFrom(asmFile);
             }
             catch


### PR DESCRIPTION
I have been writing a script which uses Appium.WebDriver.

It has a factory which executes this statement:
`Assembly.Load("WebDriver").GetType("OpenQA.Selenium.Remote.HttpCommandExecutor")`

My script had already loaded assemblies WebDriver and WebDriver.Support.

`Assembly.Load("WebDriver")` was resolving to WebDriver.Support.

This pull request ensures that the full assembly short name is matched by checking for the trailing comma. For reference the full assembly names are:

WebDriver, Version=3.141.0.0, Culture=neutral, PublicKeyToken=null
WebDriver.Support, Version=3.141.0.0, Culture=neutral, PublicKeyToken=null