### PR TITLE
Use and forward additional nuget arguments

### DIFF
--- a/src/cscs/NuGet.Core.cs
+++ b/src/cscs/NuGet.Core.cs
@@ -61,7 +61,7 @@ namespace csscript
 
         public bool NewPackageWasInstalled { get; set; }
 
-        public void InstallPackage(string packageNameMask, string version = null)
+        public void InstallPackage(string packageNameMask, string version = null, string nugetArgs = null)
         {
             var packages = new string[0];
             //index is 1-based, exactly as it is printed with ListPackages
@@ -102,7 +102,13 @@ namespace csscript
                         var ver = "";
                         if (version != null)
                             ver = "-v " + version;
-                        "dotnet".Run($"add package {name} {ver}", nuget_dir, x => Console.WriteLine(x));
+
+                        if (string.IsNullOrEmpty(nugetArgs))
+                            nugetArgs = "";
+
+                        // Syntax: dotnet add <PROJECT (optional)> package [options] <PACKAGE_NAME>
+                        string commandLine = $"add package {ver} {nugetArgs} {name}";
+                        "dotnet".Run(commandLine, nuget_dir, x => Console.WriteLine(x));
                     }
 
                     // intercept and report incompatible packages (maybe)
@@ -390,7 +396,7 @@ namespace csscript
 
                         try
                         {
-                            InstallPackage(package, packageVersion);
+                            InstallPackage(package, packageVersion, nugetArgs);
                             package_info = FindPackage(package, packageVersion);
                             this.NewPackageWasInstalled = true;
                         }


### PR DESCRIPTION
Hi Oleg,

I've an use case which needs to specify a personal nuget / artifactory respository. Therefore I tried to add the source with:

`//css_nuget -ng:"-s https://artifactory.mydomain.com/artifactory/api/nuget/my-nuget-provider" CS-Script`

Unfortunately that didn't work out very well. During debugging I discovered that `nugetArgs` set by `string nugetArgs = packageArgs.ArgValue("-ng");` is not used or forwarded to `InstallPackage`. This patch fixes that one.

In addition two other things came to my mind:
1. When I call the script by `cscs myScript.cs` the nuget packages will be downloaded. However, the script fails when `css -vs myScript.cs` is called and the local nuget cache is empty. It seems that `bool suppressDownloading` is set with `var refPkAsms = this.ResolvePackages(true); //suppressDownloading` but I've no idea why we need this flag.

2. My script I've written is placed in a git repository which has it's own NuGet.config. This configuration defines also my private artifactory. So the assumption was originally that the script is this configuration too, since it is placed in a parent directory. But the generated project is placed in `%temp%`. I could be a good idea to copy the NuGet.config to the `%temp` directory together with the temporary `build.csproj`.

So far,
Florian