### PR TITLE
Do not overwrite return code set in Environment.ExitCode

### DIFF
--- a/src/cscs/Program.cs
+++ b/src/cscs/Program.cs
@@ -34,7 +34,7 @@ namespace cscs
     static class Program
     {
         [STAThread]
-        static int Main(string[] args)
+        static void Main(string[] args)
         {
             try
             {
@@ -69,12 +69,11 @@ namespace cscs
                     CSExecutionClient.Run(args);
 
                 //  Process.GetCurrentProcess().Kill(); // some background monitors may keep the app alive too long
-                return 0;
             }
             catch (Exception e)
             {
                 Console.WriteLine(e.ToString());
-                return 1;
+                Environment.ExitCode = 1;
             }
         }
     }


### PR DESCRIPTION
Hi Oleg,

it's me again. I just figured out that the return code was handled wrong when I execute scripts by `cscs myScript.cs`

```c#
//css_args -ac
 
using System;

class MyClass
{
    public static int Main(string[] args)
    {
        Console.WriteLine("My Test");
        return -2;
    }
}
```

Expectation is here that the error level is set to `-2` after running this script, but it's `0`.
I debugged it at found that the `Main` function of `cscs` overwrites the return code set in `Environment.ExitCode`.
This commit changes the signature to void and removes the `return` statements.

Florian