### PR TITLE
Small improvements on CS Script usabilty

### DIFF
--- a/src/cscs/NuGet.Core.cs
+++ b/src/cscs/NuGet.Core.cs
@@ -316,6 +316,10 @@ namespace csscript
 
         PackageInfo FindPackage(string name, string version)
         {
+            // Create nuget cache directory if we are on a blank system
+            if (!Directory.Exists(NuGetCache))
+                Directory.CreateDirectory(NuGetCache);
+
             var packages = Directory.GetDirectories(NuGetCache, name, SearchOption.TopDirectoryOnly)
                             .SelectMany(x =>
                             {

--- a/src/cscs/csscript.cs
+++ b/src/cscs/csscript.cs
@@ -68,12 +68,13 @@ namespace csscript
                 Process p = null;
                 if (request == AppArgs.vs)
                 {
+                    string processStartArg = $"\"{projectFile}\" \"{options.scriptFileName}\"";
                     print("Opening project: " + projectFile);
                     if (vs_exe.IsEmpty())
                     {
                         try
                         {
-                            p = Process.Start("devenv", $"\"{projectFile}\"");
+                            p = Process.Start("devenv", processStartArg);
                         }
                         catch
                         {
@@ -81,7 +82,7 @@ namespace csscript
                         }
                     }
                     else
-                        p = Process.Start(vs_exe, $"\"{projectFile}\"");
+                        p = Process.Start(vs_exe, processStartArg);
                 }
                 else
                 {


### PR DESCRIPTION
During roll out of the current version of CS Script, I've collected some feedback from my team and tried to fix it. All of them are not quiet big or critical.
First commit opens again the script to run in Visual Studio again. This was really helpful in old CS Script versions (3.x), but got lost while migrating to 4.x basis as far as I can see.

Second commit fixes an error which occurs on system without an existing `.nuget\packages` directory, but the script tries to download or add a reference to a NuGet package.

```
Error: Specified file could not be compiled.
Could not find a part of the path 'C:\Users\currentUser\.nuget\packages'.
```

The exception said:
```
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, Boolean isNormalized, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.UserDirectories(String directory, String expression, EnumerationOptions options)
   at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.Directory.GetDirectories(String path, String searchPattern, SearchOption searchOption)
   at csscript.NuGetCore.FindPackage(String name, String version) in C:\source\cs-script\src\cscs\NuGet.Core.cs:line 319
   at csscript.NuGetCore.Resolve(String[] packages, Boolean suppressDownloading, String script) in C:\source\cs-script\src\cscs\NuGet.Core.cs:line 369
   at csscript.NuGet.Resolve(String[] packages, Boolean suppressDownloading, String script) in C:\source\cs-script\src\cscs\NuGet.Core.cs:line 49
   at CSScriptLib.ScriptParser.ResolvePackages(Boolean suppressDownloading) in C:\source\cs-script\src\cscs\ScriptParser.cs:line 116
   at csscript.CSExecutor.AggregateReferencedAssemblies(ScriptParser parser) in C:\source\cs-script\src\cscs\csscript.cs:line 1474
   at csscript.CSExecutor.AddReferencedAssemblies(CompilerParameters compilerParams, String scriptFileName, ScriptParser parser) in C:\source\cs-script\src\cscs\csscript.cs:line 1405
   at csscript.CSExecutor.Compile(String scriptFileName) in C:\source\cs-script\src\cscs\csscript.cs:line 1639
   at csscript.CSExecutor.ExecuteImpl() in C:\source\cs-script\src\cscs\csscript.cs:line 983
```

Best regards,
Florian