### PR TITLE
Bugfix when using embedded PDBs, #278

### DIFF
--- a/src/CSScriptLib/src/CSScriptLib/Evaluator.Roslyn.cs
+++ b/src/CSScriptLib/src/CSScriptLib/Evaluator.Roslyn.cs
@@ -424,7 +424,9 @@ namespace CSScriptLib
                     var emitOptions = new EmitOptions(false, CSScript.EvaluatorConfig.PdbFormat);
 
                     EmitResult result;
-                    if (IsDebug)
+                    if (IsDebug && CSScript.EvaluatorConfig.PdbFormat == DebugInformationFormat.Embedded)
+                        result = compilation.Emit(asm, options: emitOptions);
+                    else if (IsDebug)
                         result = compilation.Emit(asm, pdb, options: emitOptions);
                     else
                         result = compilation.Emit(asm);
@@ -471,7 +473,7 @@ namespace CSScriptLib
                         if (info?.AssemblyFile != null)
                             File.WriteAllBytes(info.AssemblyFile, buffer);
 
-                        if (IsDebug)
+                        if (IsDebug && CSScript.EvaluatorConfig.PdbFormat != DebugInformationFormat.Embedded)
                         {
                             pdb.Seek(0, SeekOrigin.Begin);
                             byte[] pdbBuffer = pdb.GetBuffer();


### PR DESCRIPTION
I missed this when reviewing https://github.com/oleg-shilo/cs-script/commit/9209e8498fd200d4dee2650df35bf2d94c743e89 as part of #278. If an embedded PDB format is specified when calling `compilation.Emit`, a PDB output stream cannot also be specified or the call will throw an exception. I've added a special case for the call to `compilation.Emit` and skipped the file write when the PDB stream is not used. I've tested this on my private repository which uses the feature and it works as intended.