### PR TITLE
Define a custom algorithm how to expand script code.

### DIFF
--- a/src/CSScriptLib/src/CSScriptLib/IEvaluator.cs
+++ b/src/CSScriptLib/src/CSScriptLib/IEvaluator.cs
@@ -28,6 +28,13 @@ namespace CSScriptLib
     public delegate T MethodDelegate<T>(params object[] paramters);
 
     /// <summary>
+    /// Delegate implementing cs script statement expansion.
+    /// </summary>
+    /// <param name="text">The text to expand.</param>
+    /// <returns>Returns a string with each statement variable replaced by its value.</returns>
+    public delegate string ExpandStatementDelegate(string text);
+
+    /// <summary>
     /// Type of the assemblies to be loaded/referenced.
     /// </summary>
     public enum DomainAssemblies
@@ -187,6 +194,17 @@ namespace CSScriptLib
         {
             get { return engine; }
             set { engine = value; }
+        }
+
+        /// <summary>
+        /// Defines a custom algorithm how to expand script code. The default implementation
+        /// calls <see cref="Environment.ExpandEnvironmentVariables"/> but a host application
+        /// might define a more complex algorithm.
+        /// </summary>
+        public ExpandStatementDelegate ExpandStatementAlgorithm 
+        {
+            get => CoreExtensions.ExpandAlgorithm;
+            set => CoreExtensions.ExpandAlgorithm = value;
         }
     }
 

--- a/src/cscs/Utils/CoreExtensions.cs
+++ b/src/cscs/Utils/CoreExtensions.cs
@@ -364,10 +364,23 @@ namespace csscript
             return "\\u" + ((int)c).ToString("x4");
         }
 
+#if class_lib
+
+        internal static ExpandStatementDelegate ExpandAlgorithm { get; set; }
+
+        internal static string Expand(this string text) => ExpandAlgorithm?.Invoke(text) ?? Environment.ExpandEnvironmentVariables(text);
+
+        internal static string UnescapeExpandTrim(this string text) =>
+            CSharpParser.UnescapeDirectiveDelimiters(Expand(text)).Trim();
+
+#else
+
         internal static string Expand(this string text) => Environment.ExpandEnvironmentVariables(text);
 
         internal static string UnescapeExpandTrim(this string text) =>
             CSharpParser.UnescapeDirectiveDelimiters(Environment.ExpandEnvironmentVariables(text)).Trim();
+
+#endif
 
         internal static string NormaliseAsDirectiveOf(this string statement, string parentScript, char multiPathDelimiter)
         {


### PR DESCRIPTION
#310 implementation. 

The *EvaluatorConfig.ExpandStatementAlgorithm* directly sets the property in *CoreExtensions*. I am not sure where else to place this, as a user might want to have this immediately set for all following calls.
*CoreExtensions.Expand* will always fall back to *Environment.ExpandEnvironmentVariables*.
