### PR TITLE
Avoid adding the same path multiple times

### DIFF
--- a/src/cscs/csscript.cs
+++ b/src/cscs/csscript.cs
@@ -599,7 +599,7 @@ namespace csscript
                                             }
 
                                             foreach (string dir in impParser.ExtraSearchDirs)
-                                                newSearchDirs.Add(Path.GetFullPath(dir));
+                                                newSearchDirs.AddIfNotThere(Path.GetFullPath(dir));
 
                                             options.searchDirs = newSearchDirs.ToArray();
                                         }


### PR DESCRIPTION
This occurs when using e.g.

//css_dir Common

in multiple imported files:

script_0.cs:
//css_dir Common
...

script_1.cs:
//css_dir Common
...

script.cs:
//css_imp script_0
//css_imp script_1
...