### PR TITLE
Proposing `GetReferencedAssembliesDirectories()` convenience method

### DIFF
--- a/src/CSScriptLib/src/CSScriptLib/Evaluator.CodeDom.cs
+++ b/src/CSScriptLib/src/CSScriptLib/Evaluator.CodeDom.cs
@@ -473,6 +473,13 @@ namespace CSScriptLib
             => referencedAssemblies.ToArray();
 
         /// <summary>
+        /// Gets the referenced assemblies directories.
+        /// </summary>
+        /// <returns>The method result.</returns>
+        public override string[] GetReferencedAssembliesDirectories()
+            => referencedAssemblies.Select(r => Path.GetDirectoryName(r)).Distinct().ToArray();
+
+        /// <summary>
         /// Loads and returns set of referenced assemblies.
         /// <para>Notre: the set of assemblies is cleared on Reset.</para>
         /// </summary>

--- a/src/CSScriptLib/src/CSScriptLib/EvaluatorBase.cs
+++ b/src/CSScriptLib/src/CSScriptLib/EvaluatorBase.cs
@@ -292,6 +292,14 @@ namespace CSScriptLib
             => throw new NotImplementedException();
 
         /// <summary>
+        /// Gets the referenced assemblies directories.
+        /// </summary>
+        /// <returns>The method result.</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public virtual string[] GetReferencedAssembliesDirectories()
+            => throw new NotImplementedException();
+
+        /// <summary>
         /// Compiles C# file (script) into assembly file. The C# contains typical C# code containing
         /// a single or multiple class definition(s).
         /// </summary>


### PR DESCRIPTION
For assembly probing, the paths to the referenced directories is relevant. Rather than having to implement the functionality outside CSScriptLib, I propose to provide a `GetReferencedAssembliesDirectories()` convenience method.